### PR TITLE
partial_day breaks when summary text has "hour" instead of "day"

### DIFF
--- a/src/awaybot.rb
+++ b/src/awaybot.rb
@@ -45,6 +45,11 @@ module AwayBot
       return_day += 1 while return_day.saturday? || return_day.sunday?
       away_range = away_start..away_end
       away_duration = (away_end - away_start).to_i + 1
+      # sometimes days shows up as hours, and this breaks partial_day analysis
+      if hour_match=(/([0-9\.]+) hour/.match event.summary)
+      days = (hour_match[1].to_i / 8.0).to_s + " day"
+      event.summary.gsub! hour_match[0], days
+      end
       # Can't tell a partial day from the dates, but it is in the summary
       partial_day = (/([0-9\.]+) day/.match event.summary)[1].to_i < 1
       # subtract any weekends from the duration


### PR DESCRIPTION
This is reported upstream as https://github.com/freshbooks/awaybot/issues/19

In brief, this will turn hours into days if this detects the summary has hours, to the partial_day match will not fail.

Output with `DEBUG=true`

```
...
...
User Name (Time off - 16 hours) (2018-11-22 - 2018-11-24)
bin/awaybot.rb:50:in `block in <main>': undefined method `[]' for nil:NilClass (NoMethodError)
	from bin/awaybot.rb:33:in `each'
	from bin/awaybot.rb:33:in `<main>'
```

I have a patch for this:

```
diff --git a/bin/awaybot.rb b/bin/awaybot.rb
index a940bca..536e187 100755
--- a/bin/awaybot.rb
+++ b/bin/awaybot.rb
@@ -46,6 +46,11 @@ ics.events.each do |event|
   return_day += 1 while return_day.saturday? || return_day.sunday?
   away_range = away_start..away_end
   away_duration = (away_end - away_start).to_i + 1
+  # sometimes days shows up as hours, and this breaks partial_day analysis
+  if hour_match=(/([0-9\.]+) hour/.match event.summary)
+    days = (hour_match[1].to_i / 8.0).to_s + " day"
+    event.summary.gsub! hour_match[0], days
+  end
   # Can't tell a partial day from the dates, but it is in the summary
   partial_day = (/([0-9\.]+) day/.match event.summary)[1].to_i < 1
   # subtract any weekends from the duration
```